### PR TITLE
Adding key/value format to runbook schedules

### DIFF
--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -39,7 +39,22 @@ The `name` field is used to provide an arbitrary name to the Runbook. This field
 
 ### `schedule`
 
-The `schedule` field is used to provide a cron formatted schedule for health check execution. The specified cron schedule will be used to establish the frequency for executing the health checks defined within the Runbook.
+The `schedule` field is used to provide a cron formatted schedule for health check execution. The specified cron schedule will be used to establish the frequency to execute the health checks defined within the Runbook.
+
+It is also possible to define the schedule in a key/value based format as well as a cron based format.
+
+```yaml
+schedule:
+  second: */15
+  minute: *
+  hour: *
+  day: *
+  month: *
+  day_of_week: *
+```
+
+For key/value based schedules you may omit fields for default values ('*'); however, cron based schedules requires all 5 columns(`* * * * *`).
+
 
 ### `nodes`
 

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -45,12 +45,12 @@ It is also possible to define the schedule in a key/value based format as well a
 
 ```yaml
 schedule:
-  second: */15
-  minute: *
-  hour: *
-  day: *
-  month: *
-  day_of_week: *
+  second: '*/15'
+  minute: '*'
+  hour: '*'
+  day: '*'
+  month: '*'
+  day_of_week: '*'
 ```
 
 For key/value based schedules you may omit fields for default values ('*'); however, cron based schedules requires all 5 columns(`* * * * *`).

--- a/tests/unit/test_monitoring_schedule.py
+++ b/tests/unit/test_monitoring_schedule.py
@@ -1,0 +1,105 @@
+'''
+Test monitoring.py schedule()
+'''
+
+import mock
+import unittest
+
+from monitoring import schedule
+
+class ScheduleTest(unittest.TestCase):
+    ''' Run unit tests against the schedule method '''
+
+    def setUp(self):
+        ''' Setup mocked data '''
+        self.config = {}
+        self.dbc = mock.Mock()
+        self.logger = mock.Mock(**{
+            'info.return_value' : True,
+            'debug.return_value' : True,
+            'critical.return_value' : True,
+            'warn.return_value' : True,
+            'error.return_value' : True
+        })
+        self.target = {'ip' : '10.0.0.1', 'hostname' : 'localhost'}
+
+    def tearDown(self):
+        ''' Destroy mocked data '''
+        self.config = None
+        self.dbc = None
+        self.logger = None
+        self.target = None
+
+class TestCronSchedule(ScheduleTest):
+    ''' Test when a cron based schedule is provided '''
+    @mock.patch('monitoring.CronTrigger')
+    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
+    def runTest(self, mock_triggered):
+        ''' Execute test '''
+        scheduler = mock.Mock(**{
+            'add_job.return_value' : True
+        })
+        self.target.update({
+            'runbooks' : {
+                'test' : {
+                    'schedule' : "* * * * *",
+                    'nodes' : [
+                        'tes*'
+                    ]
+                }
+            }
+        })
+        self.assertTrue(schedule(
+            scheduler,
+            "test",
+            self.target,
+            self.config,
+            self.dbc,
+            self.logger))
+        self.assertTrue(mock_triggered.called_with(
+            minute="*",
+            hour="*",
+            day="*",
+            month="*",
+            day_of_week="*"))
+
+class TestSpecificSchedule(ScheduleTest):
+    ''' Test when a cron based schedule is provided '''
+    @mock.patch('monitoring.CronTrigger')
+    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
+    def runTest(self, mock_triggered):
+        ''' Execute test '''
+        scheduler = mock.Mock(**{
+            'add_job.return_value' : True
+        })
+        self.target.update({
+            'runbooks' : {
+                'test' : {
+                    'schedule' : {
+                        'second' : 1,
+                        'minute' : 1,
+                        'hour' : 1,
+                        'day' : 1,
+                        'month' : 1,
+                        'day_of_week' : 1
+                    },
+                    'nodes' : [
+                        'tes*'
+                    ]
+                }
+            }
+        })
+        self.assertTrue(schedule(
+            scheduler,
+            "test",
+            self.target,
+            self.config,
+            self.dbc,
+            self.logger))
+        self.assertTrue(mock_triggered.called_with(
+            second=1,
+            minute=1,
+            hour=1,
+            day=1,
+            month=1,
+            day_of_week=1))

--- a/tests/unit/test_monitoring_schedule.py
+++ b/tests/unit/test_monitoring_schedule.py
@@ -103,3 +103,36 @@ class TestSpecificSchedule(ScheduleTest):
             day=1,
             month=1,
             day_of_week=1))
+
+class TestNoSchedule(ScheduleTest):
+    ''' Test when a cron based schedule is provided '''
+    @mock.patch('monitoring.CronTrigger')
+    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
+    def runTest(self, mock_triggered):
+        ''' Execute test '''
+        scheduler = mock.Mock(**{
+            'add_job.return_value' : True
+        })
+        self.target.update({
+            'runbooks' : {
+                'test' : {
+                    'nodes' : [
+                        'tes*'
+                    ]
+                }
+            }
+        })
+        self.assertTrue(schedule(
+            scheduler,
+            "test",
+            self.target,
+            self.config,
+            self.dbc,
+            self.logger))
+        self.assertTrue(mock_triggered.called_with(
+            second=0,
+            minute='*',
+            hour='*',
+            day='*',
+            month='*',
+            day_of_week='*'))


### PR DESCRIPTION
This PR will add the ability to specify schedules in the below format while maintaining support for the existing cron style format.

```yaml
schedule:
  second: '*/15'
  minute: '*'
  hour: '*'
  day: '*'
  month: '*'
  day_of_week: '*'
```