### PR TITLE
Fixing node specification from Runbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The below example is a Runbook that will execute a monitoring plugin to determin
 
 ```yaml
 name: Verify /var/log
-schedule: "*/2 * * * *"
+schedule: "*/5 * * * *"
 nodes:
   - "*"
 checks:
@@ -61,7 +61,8 @@ This example will detect if `nginx` is running and if not, restart it.
 
 ```yaml
 name: Verify nginx is running
-schedule: "*/5 * * * *"
+schedule:
+  second: "*/30"
 nodes:
   - "*web*"
 checks:
@@ -111,7 +112,6 @@ $ sudo docker run -d --link redis:redis -v /path/to/config:/config --restart=alw
 Follow [@Automatronio on Twitter](https://twitter.com/automatronio) for the latest Automatron news and join the community in [#Automatron on Gitter](https://gitter.im/madflojo/automatron).
 
 ## License
-
 
    Copyright 2016 Benjamin Cane
 

--- a/monitoring.py
+++ b/monitoring.py
@@ -135,7 +135,8 @@ def schedule(scheduler, runbook, target, config, dbc, logger):
     )
     should_schedule = False
     for node in target['runbooks'][runbook]['nodes']:
-        if fnmatch.fnmatch(os.uname()[1], node):
+        logger.debug("Checking if target {0} is {1} from node list".format(target['hostname'], node))
+        if fnmatch.fnmatch(target['hostname'], node):
             should_schedule = True
 
     if should_schedule:


### PR DESCRIPTION
Found while working on the scheduling that the node option of a runbook does not actually work.

The reason for this is because the function to match the node name to the target hostname was checking the Automatron master hostname instead of the target hostname.

This PR fixes the above.