### PR TITLE
Removing the "nodes" runbook config item

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,6 @@ The below example is a Runbook that will execute a monitoring plugin to determin
 ```yaml
 name: Verify /var/log
 schedule: "*/5 * * * *"
-nodes:
-  - "*"
 checks:
   mem_free:
     # Check for the % of disk free create warning with 20% free and critical for 10% free
@@ -63,8 +61,6 @@ This example will detect if `nginx` is running and if not, restart it.
 name: Verify nginx is running
 schedule:
   second: "*/30"
-nodes:
-  - "*web*"
 checks:
   nginx_is_running:
     # Check if nginx is running

--- a/config/runbooks/examples/disk_free/init.yml
+++ b/config/runbooks/examples/disk_free/init.yml
@@ -1,7 +1,5 @@
 name: Verify /var/log
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   disk_free:
     # Check for the % of disk free create warning with 20% free and critical for 10% free

--- a/config/runbooks/examples/docker/clear_dangling_images.yml
+++ b/config/runbooks/examples/docker/clear_dangling_images.yml
@@ -1,7 +1,5 @@
 name: Clean up dangling images if they are found
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   find_danglers:
     execute_from: ontarget

--- a/config/runbooks/examples/docker/clear_dead_containers.yml
+++ b/config/runbooks/examples/docker/clear_dead_containers.yml
@@ -1,7 +1,5 @@
 name: Clean up dead containers if they are found
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   find_dead_containers:
     execute_from: ontarget

--- a/config/runbooks/examples/docker/init.yml
+++ b/config/runbooks/examples/docker/init.yml
@@ -1,7 +1,5 @@
 name: Verify Docker is running
 schedule: "* * * * *"
-nodes:
-  - "*"
 checks:
   docker_running:
     execute_from: ontarget

--- a/config/runbooks/examples/nginx/init.yml
+++ b/config/runbooks/examples/nginx/init.yml
@@ -1,7 +1,5 @@
 name: Verify nginx is running
 schedule: "* * * * *"
-nodes:
-  - "*"
 checks:
   nginx_is_running:
     # Check if nginx is running

--- a/docs/automatron-in-10-minutes.md
+++ b/docs/automatron-in-10-minutes.md
@@ -2,7 +2,7 @@ With Automatron and a few minutes you can setup a fully autonomous monitoring an
 
 ## Install and Configure Automatron
 
-Automatron is currently available by cloning the [GitHub Repository](https://github.com/madflojo/automatron/). With the first release candidate it will also be available via a Docker image.
+Automatron is currently available by cloning the [GitHub Repository](https://github.com/madflojo/automatron/).
 
 ### Prerequisites
 
@@ -78,8 +78,8 @@ A Runbook is a policy that defines health checks and automated actions to be per
 For this example we will create a new Runbook.
 
 ```sh
-$ mkdir -p config/runbooks/base/check_nginx
-$ vi config/runbooks/base/check_nginx/init.yml
+$ mkdir -p config/runbooks/nginx
+$ vi config/runbooks/nginx/init.yml
 ```
 
 Once the file is open simply paste the following Runbook policy.
@@ -87,8 +87,6 @@ Once the file is open simply paste the following Runbook policy.
 ```yaml
 name: Verify nginx is running
 schedule: "*/5 * * * *"
-nodes:
-  - "*web*"
 checks:
   nginx_is_running:
     # Check if nginx is running
@@ -107,17 +105,15 @@ actions:
     cmd: service nginx restart
 ```
 
-The above policy will run the `service nginx status` command every 5 minutes on any target that has a hostname that matches `*web*`. If that command fails after 2 occurrences the `restart_nginx` action will be "triggered" and executed on the target server.
+The above policy will run the `service nginx status` command every 5 minutes. If that command fails after 2 occurrences the `restart_nginx` action will be "triggered" and executed on the target server.
 
 ## Applying Runbooks to Target hosts
 
-Within the Runbook above we specified the target nodes that the runbook applies to. There is another level of targeting available within the `config/runbooks/init.yml` file. This provides additional granularity to the application of Runbooks.
-
-To get started we will replace the contents of this file with settings specific to our current task.
+To apply a runbook to our webserver targets we will need to edit the `config/runbooks/init.yml` file. This file is used to control which hosts runbooks are applied to. The below will apply the newly created `nginx` runbook to any host whose Hostname contains `web`.
 
 ```yaml
-'*':
-  - base/check_nginx
+'*web*':
+  - nginx
 ```
 
 ## Starting Automatron

--- a/docs/facts.md
+++ b/docs/facts.md
@@ -5,8 +5,6 @@ The below is an example runbook that utilizes the Automatron facts system.
 ```yaml+jinja
 name: Verify nginx is running
 schedule: "*/5 * * * *"
-nodes:
-  - "*web*"
 checks:
   nginx_is_running:
     # Check if nginx is running

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,6 @@ The below example is a Runbook that will execute a monitoring plugin to determin
 ```yaml
 name: Verify /var/log
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   mem_free:
     # Check for the % of disk free create warning with 20% free and critical for 10% free
@@ -60,8 +58,6 @@ This example will detect if `nginx` is running and if not, restart it.
 ```yaml+jinja
 name: Verify nginx is running
 schedule: "*/5 * * * *"
-nodes:
-  - "*web*"
 checks:
   nginx_is_running:
     # Check if nginx is running

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,4 +1,4 @@
-Runbooks within Automatron are used to define the health checks to run on target nodes and the actions to perform based on those health checks. This guide is a reference for the various options used when defining a runbook.
+Runbooks within Automatron are used to define health checks and actions that are performed on monitored targets. This guide serves as a reference for the various options for runbooks.
 
 ## Basic Runbook Example
 
@@ -7,8 +7,6 @@ The below example is a basic Runbook that monitors the status of **nginx** by ex
 ```yaml
 name: Verify nginx is running
 schedule: "*/5 * * * *"
-nodes:
-  - "*web*"
 checks:
   nginx_is_running:
     # Check if nginx is running
@@ -55,28 +53,9 @@ schedule:
 
 For key/value based schedules you may omit fields for default values ('*'); however, cron based schedules requires all 5 columns(`* * * * *`).
 
-
-### `nodes`
-
-The `nodes` field is a YAML list used to specify which target nodes this runbook should be applied to. This list is based on the hostname value of the nodes.
-
-In the example above the value is `*web*`, since Automatron supports globbing for the `nodes` field this would mean this runbook is applied to any hosts that have the word "web" in their hostname.
-
-Hostnames are obtained during the target vetting process from the systems itself. If the hostname changes from vetting time to execution time that change will not be reflected in runbook processing.
-
-As previously mentioned this field is a YAML list which allows for multiple values to be added. The example below shows how to add multiple node targets.
-
-```yaml
-nodes:
-  - "*web*"
-  - "*caching*"
-```
-
 ### `checks`
 
-The `checks` field is a YAML dictionary that contains the health checks to be executed against the specified nodes in the `nodes` list.
-
-The format of `checks` is as follows.
+The `checks` field is a YAML dictionary that contains the health checks to be executed against monitored target hosts. The format of `checks` is as follows.
 
 ```yaml
 checks:
@@ -349,8 +328,6 @@ This Runbook validates an HTTP service is accessible and will restart the system
 ```yaml+jinja
 name: Verify HTTP is responding to GET requests on target system
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   http_is_accessible:
     execute_from: remote
@@ -397,8 +374,6 @@ This example will validate the free space on the `/var/log` filesystem and if ne
 ```yaml+jinja
 name: Verify /var/log
 schedule: "*/2 * * * *"
-nodes:
-  - "*"
 checks:
   disk_free:
     # Check for the % of disk free create warning with 20% free and critical for 10% free

--- a/monitoring.py
+++ b/monitoring.py
@@ -11,8 +11,6 @@ Automatron: Monitoring
 
 '''
 
-import fnmatch
-import os
 import sys
 import signal
 import json
@@ -133,20 +131,11 @@ def schedule(scheduler, runbook, target, config, dbc, logger):
         month=task_schedule['month'],
         day_of_week=task_schedule['day_of_week'],
     )
-    should_schedule = False
-    for node in target['runbooks'][runbook]['nodes']:
-        logger.debug("Checking if target {0} is {1} from list".format(target['hostname'], node))
-        if fnmatch.fnmatch(target['hostname'], node):
-            should_schedule = True
-
-    if should_schedule:
-        return scheduler.add_job(
-            monitor,
-            trigger=cron,
-            args=[runbook, target, config, dbc, logger]
-        )
-    else:
-        return False
+    return scheduler.add_job(
+        monitor,
+        trigger=cron,
+        args=[runbook, target, config, dbc, logger]
+    )
 
 def listen(scheduler, config, dbc, logger):
     ''' Listen for new events and schedule runbooks '''

--- a/tests/unit/test_monitoring_schedule.py
+++ b/tests/unit/test_monitoring_schedule.py
@@ -33,7 +33,6 @@ class ScheduleTest(unittest.TestCase):
 class TestCronSchedule(ScheduleTest):
     ''' Test when a cron based schedule is provided '''
     @mock.patch('monitoring.CronTrigger')
-    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
     def runTest(self, mock_triggered):
         ''' Execute test '''
         scheduler = mock.Mock(**{
@@ -43,9 +42,6 @@ class TestCronSchedule(ScheduleTest):
             'runbooks' : {
                 'test' : {
                     'schedule' : "* * * * *",
-                    'nodes' : [
-                        'tes*'
-                    ]
                 }
             }
         })
@@ -66,7 +62,6 @@ class TestCronSchedule(ScheduleTest):
 class TestSpecificSchedule(ScheduleTest):
     ''' Test when a cron based schedule is provided '''
     @mock.patch('monitoring.CronTrigger')
-    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
     def runTest(self, mock_triggered):
         ''' Execute test '''
         scheduler = mock.Mock(**{
@@ -83,9 +78,6 @@ class TestSpecificSchedule(ScheduleTest):
                         'month' : 1,
                         'day_of_week' : 1
                     },
-                    'nodes' : [
-                        'tes*'
-                    ]
                 }
             }
         })
@@ -107,7 +99,6 @@ class TestSpecificSchedule(ScheduleTest):
 class TestNoSchedule(ScheduleTest):
     ''' Test when a cron based schedule is provided '''
     @mock.patch('monitoring.CronTrigger')
-    @mock.patch('monitoring.fnmatch.fnmatch', new=mock.MagicMock(return_value=True))
     def runTest(self, mock_triggered):
         ''' Execute test '''
         scheduler = mock.Mock(**{
@@ -116,9 +107,6 @@ class TestNoSchedule(ScheduleTest):
         self.target.update({
             'runbooks' : {
                 'test' : {
-                    'nodes' : [
-                        'tes*'
-                    ]
                 }
             }
         })


### PR DESCRIPTION
The `nodes` runbook configuration item was adding a bit of confusion and when deployed in reality did not provide that much benefit on top of the `config/runbooks/init.yml` target specification.