### PR TITLE
Credentials override

### DIFF
--- a/actioning.py
+++ b/actioning.py
@@ -128,8 +128,15 @@ def get_runbooks_to_exec(item, target, logger):
 
 def execute_runbook(action, target, config, logger):
     ''' Execute action against target '''
+    # Setup default fabric environment
     fabric.api.env = core.fab.set_env(config, fabric.api.env)
+    # Check need for override
+    if "credentials" in action:
+        fabric.api.env = core.fab.set_env(config, fabric.api.env, override=action['credentials'])
+
     results = None
+
+    # Start plugin based action
     if "plugin" in action['type']:
         plugin_file = action['plugin']
         plugin_file = '{0}/actions/{1}'.format(config['plugin_path'], plugin_file)
@@ -161,6 +168,8 @@ def execute_runbook(action, target, config, logger):
             except Exception as e:
                 logger.debug("Could not execute plugin {0} for target {1}: {2}".format(
                     plugin_file, target['ip'], e.message))
+
+    # Start command based action
     else:
         cmd = action['cmd']
         # Perform Check
@@ -179,6 +188,8 @@ def execute_runbook(action, target, config, logger):
                     return False
             except Exception as e:
                 logger.debug("Could not execute command {0}".format(cmd))
+
+    # Check results
     if results:
         if results.succeeded is True:
             return True

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -2,13 +2,23 @@
 config_path: config
 runbook_path: config/runbooks
 plugin_path: plugins/
-ssh:
-  user: root
-  gateway: False
-  key: |
-        -----BEGIN RSA PRIVATE KEY-----
-        fdlkfjasldjfsaldkjflkasjflkjaflsdlkfjs
-        -----END RSA PRIVATE KEY-----
+
+## Credentials store for SSH logins
+credentials:
+  default: # Default is required
+    user: root
+    gateway: False
+    key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          fdlkfjasldjfsaldkjflkasjflkjaflsdlkfjs
+          -----END RSA PRIVATE KEY-----
+  example1:
+    user: notroot
+    gateway: 10.0.0.1
+    key: |
+          -----BEGIN RSA PRIVATE KEY-----
+          fdlkfjasldjfsaldkjflkasjflkjaflsdlkfjs
+          -----END RSA PRIVATE KEY-----
 
 ## Checks
 monitoring:

--- a/core/fab.py
+++ b/core/fab.py
@@ -1,14 +1,20 @@
 ''' Fabric helper file '''
 
 
-def set_env(config, env):
+def set_env(config, env, override="default"):
     ''' Set some default env values '''
     env.disable_known_hosts = True
     env.warn_only = True
     env.abort_on_prompts = False
     env.shell = "/bin/sh -c"
-    if config['ssh']['gateway']:
-        env.gateway = config['ssh']['gateway']
-    env.user = config['ssh']['user']
-    env.key = config['ssh']['key']
+    if "ssh" in config:
+        if config['ssh']['gateway']:
+            env.gateway = config['ssh']['gateway']
+        env.user = config['ssh']['user']
+        env.key = config['ssh']['key']
+    else:
+        if config['credentials'][override]['gateway']:
+            env.gateway = config['credentials'][override]['gateway']
+        env.user = config['credentials'][override]['user']
+        env.key = config['credentials'][override]['key']
     return env

--- a/tests/unit/test_actioning_execute_runbook.py
+++ b/tests/unit/test_actioning_execute_runbook.py
@@ -60,6 +60,7 @@ class TestCMDonRemote(ExecuteRunbooksTest):
         self.assertTrue(mock_local.called)
         mock_local.assert_called_with("bash", capture=True)
 
+
 class TestCMDonHostTarget(ExecuteRunbooksTest):
     ''' Test when the action is a command from Remote '''
     @mock.patch('actioning.core.fab.set_env')
@@ -238,7 +239,6 @@ class TestPluginonHostTarget(ExecuteRunbooksTest):
         self.assertFalse(self.logger.warn.called)
         self.assertTrue(mock_run.called)
         self.assertFalse(mock_local.called)
-        print mock_run.call_count
         self.assertTrue(mock_run.call_count == 3)
 
 class TestPluginBadTarget(ExecuteRunbooksTest):
@@ -280,3 +280,33 @@ class TestPluginBadTarget(ExecuteRunbooksTest):
         results = execute_runbook(action, self.target, self.config, self.logger)
         self.assertFalse(results)
         self.assertTrue(self.logger.warn.called)
+
+class TestWithOverride(ExecuteRunbooksTest):
+    ''' Test when the action is a command from Remote '''
+    @mock.patch('actioning.core.fab.set_env')
+    @mock.patch('actioning.fabric.api.env')
+    @mock.patch('actioning.fabric.api.hide')
+    @mock.patch('actioning.fabric.api.local')
+    @mock.patch('actioning.fabric.api.put')
+    @mock.patch('actioning.fabric.api.run')
+    def runTest(self, mock_run, mock_put, mock_local, mock_hide, mock_env, mock_set_env):
+        ''' Execute test '''
+        # Set mock_env to empty dict
+        mock_env = mock.MagicMock(spec={})
+        mock_set_env.return_value = mock_env
+        mock_local.return_value = mock.MagicMock(**{ 'succeeded': True})
+        mock_run.return_value = mock.MagicMock(**{ 'succeeded': True})
+        mock_put = True
+        mock_hide = True
+        action = {
+            'type' : 'cmd',
+            'execute_from' : 'remote',
+            'cmd' : "bash",
+            'credentials' : 'fake'
+        }
+        results = execute_runbook(action, self.target, self.config, self.logger)
+        self.assertTrue(results)
+        self.assertFalse(self.logger.warn.called)
+        self.assertTrue(mock_local.called)
+        mock_local.assert_called_with("bash", capture=True)
+        mock_set_env.assert_called_with(self.config, mock_env, override="fake")


### PR DESCRIPTION
This pull request allows a runbook to override the default SSH credentials/fabric environment by adding the credentials themselves into the `config.yml` and a key `credentials` in the check or action section.

Here is an example with the override set for salt hosts.

```yaml+jinja
name: Win
schedule:
  second: "*/20"
checks:
  check_win:
    execute_from: target
    type: cmd
    cmd: test -d /etc
    {% if "salt" in facts['hostname'] %}
    credentials: salt
    {% endif %}
actions:
  nada:
    execute_from: target
    type: cmd
    cmd: echo "1"
    trigger: 0
    frequency: 120
    call_on:
      - CRITICAL
      - WARNING
      - UNKNOWN
    {% if "salt" in facts['hostname'] %}
    credentials: salt
    {% endif %}
```