### PR TITLE
Fixing Fabric issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:latest
 RUN apt-get update --fix-missing && \
     apt-get -y upgrade && \
     apt-get -y install \
@@ -11,7 +11,7 @@ RUN apt-get update --fix-missing && \
     libssl-dev && \
     rm -rf /var/lib/apt/lists/*
 ADD requirements.txt /
-RUN pip install --upgrade setuptools
+RUN pip install --upgrade setuptools pip
 RUN pip install -r /requirements.txt
 RUN pip install honcho
 ADD . /

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ coverage
 boto3
 flask
 enum
+requests


### PR DESCRIPTION
Seems to be an issue with some of the Python dependencies that broke Fabric. Upgrading `pip` and using the latest Ubuntu release seems to have resolved it. I'm assuming its due to new versions of those Python libraries being installed that is doing it.