### PR TITLE
execute_runbook bugfix

### DIFF
--- a/actioning.py
+++ b/actioning.py
@@ -198,13 +198,7 @@ def execute_runbook(action, target, config, logger):
                 logger.debug("Could not execute command {0}".format(cmd))
 
     # Check results
-    if results:
-        if results.succeeded is True:
-            return True
-        else:
-            return False
-    else:
-        return False
+    return results.succeeded
 
 def shutdown(signum, frame):
     ''' Shutdown this process '''


### PR DESCRIPTION
Changing how fabric results are checked, because the check fails if the script has no stdout. 

Explanation:
We have the following condition:
```
results = fabric.api.local(cmd, capture=True)
...
if results:
  if results.succeeded:
```
This will work if `cmd` produces any output. In case it does not have stdout, an empty string will be assigned to `results` and will fail the `if results` condition, proved by the following snippet:

```
>>> results = ''
>>> if results: print("condition is true")
... else: print("condition is false")
... 
condition is false
```
This will print failed messages to log output and will not update `last_run` time.

Steps to reproduce:
1. Write a script plugin that won't produce stdout (example below)
2. Add this action to a check
3. Wait for the action to be executed
4. Action will execute successfully but will produce "failed" log messages.

Script code:
```
#!/bin/bash

true
if [ $? -eq 0 ]; then
  # uncomment echo to make it work
  # echo "ok" 
  exit 0
else
  exit 1
fi

```